### PR TITLE
feat(dashdirect): Custom Icon URL and Gift Card metadata

### DIFF
--- a/dashpay/src/main/kotlin/org/dashj/platform/contracts/wallet/TxMetadataItem.kt
+++ b/dashpay/src/main/kotlin/org/dashj/platform/contracts/wallet/TxMetadataItem.kt
@@ -19,6 +19,13 @@ import org.dashj.platform.dpp.util.Cbor
  * @property currencyCode
  * @property taxCategory
  * @property service
+ * @property giftCardNumber
+ * @property giftCardPin
+ * @property merchantName
+ * @property originalPrice
+ * @property barcodeValue
+ * @property barcodeFormat
+ * @property giftCardUrl
  * @constructor Create empty Tx metadata item
  */
 
@@ -30,6 +37,13 @@ class TxMetadataItem(
     val currencyCode: String? = null,
     val taxCategory: String? = null,
     val service: String? = null,
+    val giftCardNumber: String? = null,
+    val giftCardPin: String? = null,
+    val merchantName: String? = null,
+    val originalPrice: Long? = null,
+    val barcodeValue: String? = null,
+    val barcodeFormat: String? = null,
+    val giftCardUrl: String? = null,
     val version: Int = 0
 ) {
     val data = hashMapOf<String, Any?>()
@@ -43,6 +57,15 @@ class TxMetadataItem(
         rawObject["currencyCode"] as? String,
         rawObject["taxCategory"] as? String,
         rawObject["service"] as? String,
+
+        // Gift Cards
+        rawObject["giftCardNumber"] as? String,
+        rawObject["giftCardPin"] as? String,
+        rawObject["merchantName"] as? String,
+        rawObject["originalPrice"] as? Long,
+        rawObject["barcodeValue"] as? String,
+        rawObject["barcodeFormat"] as? String,
+        rawObject["giftCardUrl"] as? String,
         rawObject["version"] as Int
     ) {
         data.putAll(rawObject)
@@ -75,6 +98,34 @@ class TxMetadataItem(
             map["service"] = it
         }
 
+        giftCardNumber?.let {
+            map["giftCardNumber"] = it
+        }
+
+        giftCardPin?.let {
+            map["giftCardPin"] = it
+        }
+
+        merchantName?.let {
+            map["merchantName"] = it
+        }
+
+        originalPrice?.let {
+            map["originalPrice"] = it
+        }
+
+        barcodeValue?.let {
+            map["barcodeValue"] = it
+        }
+
+        barcodeFormat?.let {
+            map["barcodeFormat"] = it
+        }
+
+        giftCardUrl?.let {
+            map["giftCardUrl"] = it
+        }
+
         return map
     }
     fun getSize(): Int {
@@ -91,7 +142,14 @@ class TxMetadataItem(
                 exchangeRate == other.exchangeRate &&
                 currencyCode == other.currencyCode &&
                 taxCategory == other.taxCategory &&
-                service == other.service
+                service == other.service &&
+                giftCardNumber == other.giftCardNumber &&
+                giftCardPin == other.giftCardPin &&
+                merchantName == other.merchantName &&
+                originalPrice == other.originalPrice &&
+                barcodeValue == other.barcodeValue &&
+                barcodeFormat == other.barcodeFormat &&
+                giftCardUrl == other.giftCardUrl
         }
         return false
     }
@@ -106,10 +164,16 @@ class TxMetadataItem(
     }
 
     override fun toString(): String {
-        return "TxMetadataItem(ver=$version, ${txId.toHex()}, memo=$memo, rate=$exchangeRate, code=$currencyCode, taxCategory=$taxCategory, service=$service}"
+        return "TxMetadataItem(ver=$version, ${txId.toHex()}, memo=$memo, rate=$exchangeRate, " +
+                "code=$currencyCode, taxCategory=$taxCategory, service=$service, giftCardNumber=$giftCardNumber, " +
+                "giftCardPin=$giftCardPin, merchantName=$merchantName, originalPrice=$originalPrice, " +
+                "barcodeValue=$barcodeValue, barcodeFormat=$barcodeFormat, giftCardUrl=$giftCardUrl)"
     }
 
     fun isNotEmpty(): Boolean {
-        return (timestamp != null && timestamp != 0L) || taxCategory != null || memo != null || currencyCode != null || exchangeRate != null || service != null
+        return (timestamp != null && timestamp != 0L) || taxCategory != null || memo != null ||
+                currencyCode != null || exchangeRate != null || service != null || giftCardNumber != null ||
+                giftCardPin != null || merchantName != null || originalPrice != null || barcodeValue != null ||
+                barcodeFormat != null || giftCardUrl != null
     }
 }

--- a/dashpay/src/main/kotlin/org/dashj/platform/contracts/wallet/TxMetadataItem.kt
+++ b/dashpay/src/main/kotlin/org/dashj/platform/contracts/wallet/TxMetadataItem.kt
@@ -173,15 +173,15 @@ class TxMetadataItem(
 
     override fun toString(): String {
         return "TxMetadataItem(ver=$version, ${txId.toHex()}, memo=$memo, rate=$exchangeRate, " +
-                "code=$currencyCode, taxCategory=$taxCategory, service=$service, customIconUrl=$customIconUrl, " +
-                "giftCardNumber=$giftCardNumber, giftCardPin=$giftCardPin, merchantName=$merchantName, " +
-                "originalPrice=$originalPrice, barcodeValue=$barcodeValue, barcodeFormat=$barcodeFormat, merchantUrl=$merchantUrl)"
+            "code=$currencyCode, taxCategory=$taxCategory, service=$service, customIconUrl=$customIconUrl, " +
+            "giftCardNumber=$giftCardNumber, giftCardPin=$giftCardPin, merchantName=$merchantName, " +
+            "originalPrice=$originalPrice, barcodeValue=$barcodeValue, barcodeFormat=$barcodeFormat, merchantUrl=$merchantUrl)"
     }
 
     fun isNotEmpty(): Boolean {
         return (timestamp != null && timestamp != 0L) || taxCategory != null || memo != null ||
-                currencyCode != null || exchangeRate != null || service != null || customIconUrl != null ||
-                giftCardNumber != null || giftCardPin != null || merchantName != null || originalPrice != null ||
-                barcodeValue != null || barcodeFormat != null || merchantUrl != null
+            currencyCode != null || exchangeRate != null || service != null || customIconUrl != null ||
+            giftCardNumber != null || giftCardPin != null || merchantName != null || originalPrice != null ||
+            barcodeValue != null || barcodeFormat != null || merchantUrl != null
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
In DashPay, we want to synchronize the custom transaction icons and gift card data with the Platform.

## What was done?
- Added additional fields to the TxMetadataItem


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone